### PR TITLE
Fix/json download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Project specific
+data/predictions/*.json
+data/predictions/*.csv


### PR DESCRIPTION
## Changes Made
- Modified `prediction_history.py` to handle both single prediction dictionaries and arrays of predictions
- Added better error handling with informative messages
- Added `.gitignore` rules for prediction files

## Bug Fix Details
The application was failing when trying to load prediction history because some JSON files contained arrays of predictions while others contained single prediction dictionaries. This fix:
1. Handles both formats correctly
2. Provides better error messages
3. Prevents prediction files from being tracked in git

## Testing
- Tested loading both single prediction files and history export files
- Verified error messages are more informative
- Confirmed prediction files are properly ignored by git

## Related Issues
Fixes the JSON download and loading issues in the prediction history feature.